### PR TITLE
chore: update TypeScript configuration and fix Stellar SDK import path

### DIFF
--- a/apps/server/src/modules/htlc/stellar-monitoring.ts
+++ b/apps/server/src/modules/htlc/stellar-monitoring.ts
@@ -1,4 +1,4 @@
-import { Api, Server } from '@stellar/stellar-sdk/lib/rpc';
+import { Api, Server } from '@stellar/stellar-sdk/rpc';
 import { ENV as env } from '../../shared/config.module';
 import { scValToNative } from '@stellar/stellar-sdk';
 

--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -1,12 +1,12 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "nodenext",
     "declaration": true,
     "removeComments": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": true,
-    "target": "ES2023",
+    "target": "esnext",
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": "./",


### PR DESCRIPTION
- Changed module setting from 'commonjs' to 'nodenext' for better module resolution.
- Updated target from 'ES2023' to 'esnext' to leverage the latest JavaScript features.
- Fixed import path for Stellar SDK from '@stellar/stellar-sdk/lib/rpc' to '@stellar/stellar-sdk/rpc' for correct module usage.